### PR TITLE
Add links to cross-referenced chapters

### DIFF
--- a/src/OEBPS/Text/tutorial_advanced_find.xhtml
+++ b/src/OEBPS/Text/tutorial_advanced_find.xhtml
@@ -18,7 +18,7 @@
     <img alt="Using Regular Expressions (regex) in Find and Replace" src="../Images/tutorial-find-adv-regex.png"/>
   </div>
 
-  <p>Regex is a very important tool in Sigil, but only a very brief introduction can be given in this tutorial. See the next chapter for a reference list of regular expressions.</p>
+  <p>Regex is a very important tool in Sigil, but only a very brief introduction can be given in this tutorial. See the next chapter (<a href="tutorial_regex_reference.xhtml">Regular Expression Reference</a>) for a reference list of regular expressions.</p>
 
   <p>For example, instead of searching for very specific text to replace or delete, such as “Page 123”, it would be much more useful to search for text that contains “Page” followed by a number – that’s exactly what regular expressions can provide.</p>
 

--- a/src/OEBPS/Text/tutorial_convert_to_html.xhtml
+++ b/src/OEBPS/Text/tutorial_convert_to_html.xhtml
@@ -56,7 +56,7 @@
 
 <p>To create a new EPUB book directly from a MS Word file you can use the DOCXImport plugin developed by DiapDealer. By adding this plugin you can directly import a docx into Sigil as html.</p>
 
-<p><a href="https://www.mobileread.com/forums/showthread.php?t=273966">DOCXImport plugin</a> (See the <b>Manage Plugins</b> chapter on how to install a plugin).</p>
+<p><a href="https://www.mobileread.com/forums/showthread.php?t=273966">DOCXImport plugin</a> (See the <a href="manage_plugins.xhtml">Manage Plugins</a> chapter on how to install a plugin).</p>
 
 <div class="tip">
     <p class="tiptext">Note: Using this plugin will create a new EPUB. If you already have an existing EPUB open in Sigil this will be replaced and any unsaved work will be discarded.</p>

--- a/src/OEBPS/Text/tutorial_generate_toc.xhtml
+++ b/src/OEBPS/Text/tutorial_generate_toc.xhtml
@@ -10,7 +10,7 @@
 <body>
   <h2>Generate A Table of Contents</h2>
 
-  <p>In order for Sigil to generate a table of contents for you, you must have already identified the chapter names. See the previous tutorial if you have not done this already.</p>
+  <p>In order for Sigil to generate a table of contents for you, you must have already identified the chapter names. See the previous tutorial (<a href="tutorial_mark_chapters.xhtml">Identify Your Chapters</a>) if you have not done this already.</p>
 
   <p>Once you have marked all your chapter headings you can click the Generate Table Of Contents button <img alt="Generate Table of Contents icon." src="../Images/generate-toc.png"/> or use the menu item <span class="menuitem">Tools=&gt;Table Of Contents=&gt;Generate Table Of Contents</span> to open a new dialog:</p>
 


### PR DESCRIPTION
for easier navigation and consistency with other cross-referenced chapters, which already have links